### PR TITLE
Python 3.7 Support, renaming async to use_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For most users, the default configuration should work perfectly. For more specif
 
 Typically, after configuring the AsyncBufferedConsumer and passing it to the Mixpanel object, you will never have to use it again. That said, there are a few methods which can be useful.
 
-* `flush()` - tells the AsyncBufferedConsumer to flush all of the events in its queues. If you call it with `async=False` this flush will happen in the main thread (useful for ensuring all events are sent before a process ends)
+* `flush()` - tells the AsyncBufferedConsumer to flush all of the events in its queues. If you call it with `use_async=False` this flush will happen in the main thread (useful for ensuring all events are sent before a process ends)
 
 ```python
 #!/usr/bin/env python

--- a/mixpanel_async/async_buffered_consumer.py
+++ b/mixpanel_async/async_buffered_consumer.py
@@ -45,7 +45,7 @@ class AsyncBufferedConsumer(SynchronousBufferedConsumer):
 
     Because AsyncBufferedConsumer holds events until the `flush_after` timeout
     or an endpoint queue hits the size of _max_queue_size, you should call
-    flush(async=False) before you terminate any process where you have been
+    flush(use_async=False) before you terminate any process where you have been
     using the AsyncBufferedConsumer.
     '''
 
@@ -163,7 +163,7 @@ class AsyncBufferedConsumer(SynchronousBufferedConsumer):
             self._flush_endpoint(endpoint)
 
 
-    def flush(self, endpoint=None, async=True):
+    def flush(self, endpoint=None, use_async=True):
         '''
         Send all remaining messages to Mixpanel. AsyncBufferedConsumers will
         flush automatically when you call send(), but you will need to call
@@ -179,12 +179,12 @@ class AsyncBufferedConsumer(SynchronousBufferedConsumer):
 
         :param endpoint (str): One of 'events' or 'people, the Mixpanel endpoint
         for sending the data
-        :param async (bool): Whether to flush the data in a seperate thread or not
+        :param use_async (bool): Whether to flush the data in a seperate thread or not
         '''
 
         flushing = False
 
-        if async:
+        if use_async:
             # this flush lock is used to guarantee that only one flushing_thread
             # is ever alive.
             with self.flush_lock:
@@ -241,11 +241,11 @@ class AsyncBufferedConsumer(SynchronousBufferedConsumer):
                 self._buffers[key].append(buf.pop(0))
 
 
-    def _flush_endpoint(self, endpoint, async=True):
+    def _flush_endpoint(self, endpoint, use_async=True):
         # we override flush with endpoint so as to keep all the
         # threading logic in one place, while still allowing individual
         # endpoints to be flushed
-        self.flush(endpoint=endpoint, async=async)
+        self.flush(endpoint=endpoint, use_async=use_async)
 
 
     def _sync_flush(self, endpoint=None):

--- a/tests/async_buffered_consumer_test.py
+++ b/tests/async_buffered_consumer_test.py
@@ -89,7 +89,7 @@ class AsyncBufferedConsumerTestCase(unittest.TestCase):
         sync_flush.side_effect = side_effect
 
         self.send_event()
-        self.consumer.flush(async=False)
+        self.consumer.flush(use_async=False)
 
     @patch.object(AsyncBufferedConsumer, '_sync_flush')
     def test_flushes_after_first_event_if_first_flush_true(self, sync_flush):


### PR DESCRIPTION
Admittedly haven't tested, but think this should work. Addresses #16 